### PR TITLE
[CardItem] 컴포넌트 내에 간단한 조건부/리스트 렌더링 구현

### DIFF
--- a/src/components/molecules/CardItem/index.tsx
+++ b/src/components/molecules/CardItem/index.tsx
@@ -25,11 +25,11 @@ export function CardItem({ item }: ItemProps): React.ReactElement {
       </dl>
       <dl>
         <dt>가공방식</dt>
-        <dd>{method}</dd>
+        <dd>{method.join(', ')}</dd>
       </dl>
       <dl>
         <dt>재료</dt>
-        <dd>{material}</dd>
+        <dd>{material.join(', ')}</dd>
       </dl>
       <div>
         <button type="button" className="request">

--- a/src/components/molecules/CardItem/index.tsx
+++ b/src/components/molecules/CardItem/index.tsx
@@ -39,7 +39,8 @@ export function CardItem({ item }: ItemProps): React.ReactElement {
           채팅하기
         </button>
       </div>
-      <span className="inquiry">{status}</span>
+
+      {status === '상담중' && <span className="inquiry">{status}</span>}
     </S.Wrapper>
   );
 }


### PR DESCRIPTION
## 구현 화면

<img width="400" alt="week2_14" src="https://user-images.githubusercontent.com/72926450/153087453-f1ec57c7-b7c7-4d84-9307-240e93ddb05c.png"> <img width="400" alt="week2_15" src="https://user-images.githubusercontent.com/72926450/153087466-a8c8093b-b89e-4562-b5ea-927930ec89fc.png">


## 구현 범위

서영님(@seoysauce)이 꼼꼼하게 챙겨주신 덕분에 아래의 내용들을 급하게나마 수정할 수 있었습니다 :-D

- `main` 브랜치에 이미 직접 반영한 내용
  - [x] **버튼의 글자 크기** 고정
  - [x] **뱃지의 폰트 스타일** 고정

- `이번 PR`에서 반영한 내용
  - [x] **뱃지의 조건부 렌더링** 구현: status가 '상담중'인 경우에만 뱃지를 표시하는 조건부 렌더링 구현
  - [x]  **가공방식의 표현 방식** 수정: `join(, )` 메서드를 method(가공방식)와 material(재료)에 적용